### PR TITLE
Disabled 'points' by default. Issue #28

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -127,16 +127,19 @@ function LTreering (viewer, basePath, options) {
       this.ioTools.bar.addTo(this.viewer);
       this.settings.bar.addTo(this.viewer);
       this.undoRedoBar.addTo(this.viewer);
+      //overlay 'points' option enabled by default in popout
+      L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
     } else {
       this.popout.btn.addTo(this.viewer);
       this.viewData.btn.addTo(this.viewer);
       this.ioTools.bar.addTo(this.viewer);
       this.settings.bar.addTo(this.viewer);
+      L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
+      //defaults overlay 'points' option to disabled
+      map.removeLayer(this.visualAsset.markerLayer);
     }
 
-    L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
-
-        // right and left click controls
+    // right and left click controls
     this.viewer.on('contextmenu', () => {
       if (!this.createPoint.active && this.data.points[0] !== undefined &&
           this.createTools.btn._currentState.stateName === 'expand') {

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -117,6 +117,8 @@ function LTreering (viewer, basePath, options) {
 
     $('#map').css('cursor', 'default');
 
+    L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
+
     // if popout is opened display measuring tools
     if (window.name.includes('popout')) {
       this.viewData.btn.addTo(this.viewer);
@@ -127,14 +129,11 @@ function LTreering (viewer, basePath, options) {
       this.ioTools.bar.addTo(this.viewer);
       this.settings.bar.addTo(this.viewer);
       this.undoRedoBar.addTo(this.viewer);
-      //overlay 'points' option enabled by default in popout
-      L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
     } else {
       this.popout.btn.addTo(this.viewer);
       this.viewData.btn.addTo(this.viewer);
       this.ioTools.bar.addTo(this.viewer);
       this.settings.bar.addTo(this.viewer);
-      L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
       //defaults overlay 'points' option to disabled
       map.removeLayer(this.visualAsset.markerLayer);
     }


### PR DESCRIPTION
Now by default: browser sets 'points' overlay to disabled & popout sets 'points' overlay to enabled.