### PR TITLE
Made annotations draggable. Issue #34

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
     var layer = L.tileLayer.elevator(function(coords, tile, done) {
         var error;
-        var params = {Bucket: 'elevator-assets', Key: "testasset5/tiledBase_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
+        var params = {Bucket: 'elevator-assets', Key: "testasset7/tiledBase_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
         //var params = {Bucket: 'elevator-assets', Key: "pmc14b_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
         tile.onload = (function(done, error, tile) {
             return function() {
@@ -67,8 +67,12 @@
         return tile.src;
     },
     {
-        width: 231782,
-        height: 4042,
+				width: 161686,
+        height: 3922,
+				//testasset5
+        //width: 231782,
+        //height: 4042,
+
         //width: 200521,
         //height: 4196,
         tileSize :254,
@@ -82,7 +86,7 @@
     //minimap
     var miniLayer = new L.tileLayer.elevator(function(coords, tile, done) {
         var error;
-        var params = {Bucket: 'elevator-assets', Key: "testasset5/tiledBase_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
+        var params = {Bucket: 'elevator-assets', Key: "testasset7/tiledBase_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
         //var params = {Bucket: 'elevator-assets', Key: "pmc14b_files/" + coords.z + "/" + coords.x + "_" + coords.y + ".jpeg"};
         tile.onload = (function(done, error, tile) {
             return function() {
@@ -95,8 +99,12 @@
         return tile.src;
     },
     {
-        width: 231782,
-        height: 4042,
+				width: 161686,
+				height: 3922,
+				//testasset5
+				//width: 231782,
+				//height: 4042,
+			
         //width: 200521,
         //height: 4196,
         tileSize: 254,

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -789,7 +789,6 @@ function VisualAsset (Lt) {
 
     this.markers[i] = marker;   //add created marker to marker_list
 
-    //annotation line color changes: red = #ff0000
     //tell marker what to do when being dragged
     this.markers[i].on('drag', (e) => {
       if (!pts[i].start) {
@@ -919,11 +918,24 @@ function AnnotationAsset(Lt) {
       return;
     }
 
-    var circle = L.circle(ref.latLng, {radius: .0001, color: 'red',
-      weight: '6'});
+    var draggable = false;
+    if (window.name.includes('popout')) {
+      draggable = true;
+    }
+
+    var circle = L.marker(ref.latLng, {
+      icon: new MarkerIcon('red', Lt.basePath),
+      draggable: draggable,
+      riseOnHover: true
+    });
+
     circle.bindPopup(ref.text, {closeButton: false});
     this.markers[i] = circle;
     this.markers[i].clicked = false;
+
+    this.markers[i].on('dragend', (e) => {
+      ants[i].latLng = e.target._latlng;
+    });
 
     $(this.markers[i]).click(e => {
       if (Lt.editAnnotation.active) {


### PR DESCRIPTION
Annotations can be dragged and their positions will be saved in the JSON file.

Changed map asset in index.html so marker data would align with core image.

Tested successfully on Firefox and Chrome. Save a local copy does not work on edge so it could not be fully tested.