### PR TITLE
Fixed marker title & changed line color. Issue #42

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
 				//testasset5
 				//width: 231782,
 				//height: 4042,
-			
+
         //width: 200521,
         //height: 4196,
         tileSize: 254,

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -118,7 +118,6 @@ function LTreering (viewer, basePath, options) {
     $('#map').css('cursor', 'default');
 
     L.control.layers(this.baseLayer, this.overlay).addTo(this.viewer);
-    map.removeLayer(this.annotationAsset.markerLayer);
 
     // if popout is opened display measuring tools
     if (window.name.includes('popout')) {
@@ -729,8 +728,7 @@ function VisualAsset (Lt) {
 
     var marker;
 
-    //check if index is the start point
-    if (pts[i].start) {
+    if (pts[i].start) { //check if index is the start point
       marker = L.marker(leafLatLng, {
         icon: new MarkerIcon('white_s', Lt.basePath),
         draggable: draggable,
@@ -744,48 +742,57 @@ function VisualAsset (Lt) {
         title: 'Break Point',
         riseOnHover: true
       });
-    } else if (Lt.meta.hasLatewood || Lt.data.earlywood) { //check if point is earlywood
-      if (pts[i].earlywood) {
-        if (pts[i].year % 10 == 0) {
-          marker = L.marker(leafLatLng, {
-            icon: new MarkerIcon('pale_red', Lt.basePath),
-            draggable: draggable,
-            title: 'Year ' + pts[i].year + ', latewood',
-            riseOnHover: true
-          });
-        } else {
-            marker = L.marker(leafLatLng, {
-              icon: new MarkerIcon('light_blue', Lt.basePath),
-              draggable: draggable,
-              title: 'Year ' + pts[i].year + ', latewood',
-              riseOnHover: true
-            });
-        }
-      } else { //otherwise it's latewood
+    } else if (Lt.meta.hasLatewood) { //check if point hasLatewood
+        if (pts[i].earlywood) { //check if point is earlywood
           if (pts[i].year % 10 == 0) {
             marker = L.marker(leafLatLng, {
-              icon: new MarkerIcon('light_red', Lt.basePath),
+              icon: new MarkerIcon('pale_red', Lt.basePath),
               draggable: draggable,
-              title: 'Year ' + pts[i].year + ', latewood',
+              title: 'Year ' + pts[i].year + ', earlywood',
               riseOnHover: true
             });
           } else {
               marker = L.marker(leafLatLng, {
-                icon: new MarkerIcon('dark_blue', Lt.basePath),
+                icon: new MarkerIcon('light_blue', Lt.basePath),
+                draggable: draggable,
+                title: 'Year ' + pts[i].year + ', earlywood',
+                riseOnHover: true
+              });
+          }
+        } else { //otherwise it's latewood
+            if (pts[i].year % 10 == 0) {
+              marker = L.marker(leafLatLng, {
+                icon: new MarkerIcon('light_red', Lt.basePath),
                 draggable: draggable,
                 title: 'Year ' + pts[i].year + ', latewood',
                 riseOnHover: true
               });
-          }
-      }
+            } else {
+                marker = L.marker(leafLatLng, {
+                  icon: new MarkerIcon('dark_blue', Lt.basePath),
+                  draggable: draggable,
+                  title: 'Year ' + pts[i].year + ', latewood',
+                  riseOnHover: true
+                });
+            }
+        }
     } else {
-      marker = L.marker(leafLatLng, {
-        icon: new MarkerIcon('light_blue', Lt.basePath),
-        draggable: draggable,
-        title: 'Year ' + pts[i].year,
-        riseOnHover: true
-      });
-    }
+      if (pts[i].year % 10 == 0) {
+        marker = L.marker(leafLatLng, {
+          icon: new MarkerIcon('light_red', Lt.basePath),
+          draggable: draggable,
+          title: 'Year ' + pts[i].year,
+          riseOnHover: true
+        })
+      } else {
+        marker = L.marker(leafLatLng, {
+          icon: new MarkerIcon('light_blue', Lt.basePath),
+          draggable: draggable,
+          title: 'Year ' + pts[i].year,
+          riseOnHover: true
+        })
+      }
+    };
 
     this.markers[i] = marker;   //add created marker to marker_list
 
@@ -856,23 +863,29 @@ function VisualAsset (Lt) {
 
     //drawing the line if the previous point exists
     if (pts[i - 1] != undefined && !pts[i].start) {
+      var opacity = '.5';
+      var weight = '3';
       if (pts[i].earlywood || !Lt.meta.hasLatewood ||
           (!pts[i - 1].earlywood && pts[i].break)) {
-        var color = '#00BCD4';
+        var color = '#17b0d4'; // original = #00BCD4 : actual = #5dbcd
       } else {
-        var color = '#00838f';
-      }
+        var color = '#026d75'; // original = #00838f : actual = #14848c
+      };
 
       //mark decades with red line
-      if ((pts[i].earlywood || !Lt.meta.hasLatewood) && pts[i].year % 10 == 0) {
-        var color = '#FC9272';
-      } else if ((!pts[i].earlywood || Lt.meta.hasLatewood) && pts[i].year % 10 == 0) {
-        var color = '#EF3B2C';
+      if (pts[i].year % 10 == 0){
+        var opacity = '.6';
+        var weight = '5';
+        if (Lt.meta.hasLatewood && pts[i].earlywood) {
+          var color = '#e06f4c' // actual = #FC9272
+        } else {
+          var color = '#db2314' // actual = #EF3B2C
+        }
       }
 
       this.lines[i] =
           L.polyline([pts[i - 1].latLng, leafLatLng],
-          {color: color, opacity: '.75', weight: '3'});
+          {color: color, opacity: opacity, weight: weight});
       this.lineLayer.addLayer(this.lines[i]);
     }
 


### PR DESCRIPTION
Changed conditions so !hasLatewood marker appears. Previously would not.

Fixed title error to differentiate earlywood / latewood.

Enabled annotations after group feedback.

Darkened line colors so markers more visible.
Customized line opacity & weight to better show decades.

Tested successfully on Chrome and Firefox.