### PR TITLE
Replace object values. Issue #49

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -322,7 +322,7 @@ function MeasurementData (dataObject) {
    */
   MeasurementData.prototype.cut = function(i, j) {
     if (i > j) {
-      var trimmed_points = Object.values(this.points).splice(i, this.index - 1);
+      var trimmed_points = this.points.slice().splice(i, this.index - 1);
       var k = 0;
       this.points = {};
       trimmed_points.map(e => {
@@ -336,7 +336,7 @@ function MeasurementData (dataObject) {
       });
       this.index = k;
     } else if (i < j) {
-      this.points = Object.values(this.points).splice(0, i);
+      this.points = this.points.slice().splice(0, i);
       this.index = i;
     } else {
       alert('You cannot select the same point');

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -499,7 +499,7 @@ function MeasurementData (dataObject) {
    */
   MeasurementData.prototype.insertZeroGrowth = function(i, latLng, hasLatewood) {
     var new_points = this.points;
-    var second_points = Object.values(this.points).splice(i + 1, this.index - 1);
+    var second_points = this.points.slice().splice(i + 1, this.index - 1);
     var k = i + 1;
 
     var year_adjusted = this.points[i].year + 1;
@@ -518,7 +518,7 @@ function MeasurementData (dataObject) {
     var tempK = k-1;
 
     second_points.map(e => {
-      if (!e.start && !e.break) {
+      if (e && !e.start && !e.break) {
         e.year++;
       }
       new_points[k] = e;

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -250,7 +250,7 @@ function MeasurementData (dataObject) {
     if (this.points[i].start) {
       if (this.points[i - 1] != undefined && this.points[i - 1].break) {
         i--;
-        second_points = Object.values(this.points).splice(i + 2, this.index - 1);
+        second_points = this.points.slice().splice(i + 2, this.index - 1);
         shift = this.points[i + 2].year - this.points[i - 1].year - 1;
         second_points.map(e => {
           e.year -= shift;
@@ -262,7 +262,7 @@ function MeasurementData (dataObject) {
         delete this.points[this.index];
         delete this.points[this.index + 1];
       } else {
-        second_points = Object.values(this.points).splice(i + 1, this.index - 1);
+        second_points = this.points.slice().splice(i + 1, this.index - 1);
         second_points.map(e => {
           if (!i) {
             this.points[i] = {'start': true, 'skip': false, 'break': false,
@@ -276,7 +276,7 @@ function MeasurementData (dataObject) {
         delete this.points[this.index];
       }
     } else if (this.points[i].break) {
-      second_points = Object.values(this.points).splice(i + 2, this.index - 1);
+      second_points = this.points.slice().splice(i + 2, this.index - 1);
       shift = this.points[i + 2].year - this.points[i - 1].year - 1;
       second_points.map(e => {
         e.year -= shift;
@@ -290,9 +290,9 @@ function MeasurementData (dataObject) {
     } else {
       var new_points = this.points;
       var k = i;
-      second_points = Object.values(this.points).splice(i + 1, this.index - 1);
+      second_points = this.points.slice().splice(i + 1, this.index - 1);
       second_points.map(e => {
-        if (!e.start && !e.break) {
+        if (e && !e.start && !e.break) {
           if (hasLatewood) {
             e.earlywood = !e.earlywood;
             if (!e.earlywood) {


### PR DESCRIPTION
Replaced Object.values(this.points).splice(....) with this.points.slice().splice(....). Object.values() is no longer needed as this.points defaults to an array not an object. Done in multiple commits to spread out changes. 

Tested successfully with Chrome and Firefox. 