### PR TITLE
Create 0 growth refactor

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -1638,7 +1638,7 @@ function CreateZeroGrowth(Lt) {
       if (Lt.data.points[Lt.data.index - 1].earlywood && Lt.measurementOptions.subAnnual) {
         var firstEWCheck = false;
         var secondEWCheck = true;
-      } else if (!Lt.data.points[Lt.data.index - 1].earlywood || !Lt.measurementOptions.subAnnual) {
+      } else {
         var firstEWCheck = true;
         var secondEWCheck = false;
       };

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -1635,13 +1635,21 @@ function CreateZeroGrowth(Lt) {
 
       Lt.undo.push();
 
+      if (Lt.data.points[Lt.data.index - 1].earlywood && Lt.measurementOptions.subAnnual) {
+        var firstEWCheck = false;
+        var secondEWCheck = true;
+      } else if (!Lt.data.points[Lt.data.index - 1].earlywood || !Lt.measurementOptions.subAnnual) {
+        var firstEWCheck = true;
+        var secondEWCheck = false;
+      };
+
       Lt.data.points[Lt.data.index] = {'start': false, 'skip': false, 'break': false,
-        'year': Lt.data.year, 'earlywood': true, 'latLng': latLng};
+        'year': Lt.data.year, 'earlywood': firstEWCheck, 'latLng': latLng};
       Lt.visualAsset.newLatLng(Lt.data.points, Lt.data.index, latLng);
       Lt.data.index++;
       if (Lt.measurementOptions.subAnnual) {
         Lt.data.points[Lt.data.index] = {'start': false, 'skip': false, 'break': false,
-          'year': Lt.data.year, 'earlywood': false, 'latLng': latLng};
+          'year': Lt.data.year, 'earlywood': secondEWCheck, 'latLng': latLng};
         Lt.visualAsset.newLatLng(Lt.data.points, Lt.data.index, latLng);
         Lt.data.index++;
       }


### PR DESCRIPTION
Added conditional to change point type (EW or LW) based on previous point.

Previously, inserted point would always be EW then LW. Caused issue if zero growth inserted on EW point. 

Tested successfully for both measurement directions. 