### PR TITLE
H-Bar Appearance Changes & Additions

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -97,7 +97,7 @@ function LTreering (viewer, basePath, options) {
   if (window.name.includes('popout'))
     this.settings = new ButtonBar(this, [this.imageAdjustment.btn, this.measurementOptions.btn, this.mouseLine.btn, this.calibration.btn], 'settings', 'Change image, measurement, and calibration settings');
   else
-    this.settings = new ButtonBar(this, [this.imageAdjustment.btn, this.measurementOptions.btn, this.mouseLine.btn], 'settings', 'Change image and measurement settings');
+    this.settings = new ButtonBar(this, [this.imageAdjustment.btn, this.measurementOptions.btn], 'settings', 'Change image and measurement settings');
 
   this.tools = [this.viewData, this.calibration, this.createAnnotation, this.deleteAnnotation, this.editAnnotation, this.dating, this.createPoint, this.createBreak, this.deletePoint, this.cut, this.insertPoint, this.insertZeroGrowth, this.insertBreak, this.imageAdjustment, this.measurementOptions];
 
@@ -853,11 +853,16 @@ function MouseLine (Lt) {
           var latLngOne = Lt.viewer.layerPointToLatLng([xOne, yOne]);
           var latLngTwo = Lt.viewer.layerPointToLatLng([xTwo, yTwo]);
 
+          // need 3 polylines so lines cover screen
           this.layer.addLayer(L.polyline([latLng, latLngOne],
               {interactive: false, color: color, opacity: '.75',
                 weight: '3'}));
 
-          this.layer.addLayer(L.polyline([latLng, latLngTwo],
+          this.layer.addLayer(L.polyline([latLng, mouseLatLng],
+              {interactive: false, color: color, opacity: '.75',
+                weight: '3'}));
+
+          this.layer.addLayer(L.polyline([mouseLatLng, latLngTwo],
               {interactive: false, color: color, opacity: '.75',
                 weight: '3'}));
 
@@ -1457,13 +1462,15 @@ function Button(icon, toolTip, enable, disable) {
   if (disable !== null) {
     if (icon == 'expand') { // only used for mouse line toggle
       var icon = 'compress';
+      var title = 'Enable proportional h-bar';
     } else {
       var icon = 'clear';
+      var title = 'Cancel';
     }
     states.push({
       stateName: 'active',
       icon: '<i class="material-icons md-18">' + icon + '</i>',
-      title: 'Cancel',
+      title: title,
       onClick: disable
     })
   }

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -874,7 +874,7 @@ function MouseLine (Lt) {
           var latLngTwo = Lt.viewer.layerPointToLatLng([xTwo, yTwo]);
 
           // path guide for point
-          this.layer.addLayer(L.polyline([latLng, mouseLatLng],
+          this.layer.addLayer(L.polyline([latLng, latLngOne],
               {interactive: false, color: color, opacity: '.75',
                 weight: '3'}));
 
@@ -885,7 +885,7 @@ function MouseLine (Lt) {
 
         };
 
-        this.layer.addLayer(L.polyline([latLng, latLngOne],
+        this.layer.addLayer(L.polyline([latLng, mouseLatLng],
             {interactive: false, color: color, opacity: '.75',
               weight: '3'}));
 

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -844,14 +844,17 @@ function MouseLine (Lt) {
             var y = (m * x) + b;
             return y;
           };
-          // values from min (0, -308) & max (1920, 355) of leaflet pixel bounds
-          var xOne = 0;
-          var xTwo = 1920;
-          var yOne  = linearEq(xOne) || -308;
-          var yTwo = linearEq(xTwo) || 355
+          // pixel bounds change w/ browsers
+          var pixelBounds = map.getPixelBounds();
+          var xOne = pixelBounds.min.x;
+          var xTwo = pixelBounds.max.x;
+          var yOne  = linearEq(xOne) || pixelBounds.min.y;
+          var yTwo = linearEq(xTwo) || pixelBounds.max.y;
 
           var latLngOne = Lt.viewer.layerPointToLatLng([xOne, yOne]);
           var latLngTwo = Lt.viewer.layerPointToLatLng([xTwo, yTwo]);
+
+          // console.log(map.getPixelBounds())
 
           // need 3 polylines so lines cover screen
           this.layer.addLayer(L.polyline([latLng, latLngOne],

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -834,7 +834,7 @@ function MouseLine (Lt) {
           var m = (mousePoint.y - point.y) / (mousePoint.x - point.x);
           var b = point.y - (m * point.x);
 
-          // find x value along a line some distance away
+          // finds x value along a line some distance away
           // found by combining linear equation & distance equation
           // https://math.stackexchange.com/questions/175896/finding-a-point-along-a-line-a-certain-distance-away-from-another-point
           function distanceToX (xNaut, distance) {
@@ -854,7 +854,7 @@ function MouseLine (Lt) {
           } else { // mouse right of point
             var pathLengthOne = -pathLength;
             var pathLengthTwo = pathLength;
-          }
+          };
 
           var xOne = distanceToX(point.x, pathLengthOne);
           var xTwo = distanceToX(mousePoint.x, pathLengthTwo);
@@ -865,7 +865,8 @@ function MouseLine (Lt) {
           } else { // mouse above point
             var verticalFixOne = point.y - pathLength;
             var verticalFixTwo = mousePoint.y + pathLength;
-          }
+          };
+
           var yOne = linearEq(xOne) || verticalFixOne; // for vertical measurements
           var yTwo = linearEq(xTwo) || verticalFixTwo; // vertical asymptotes: slope = undefined
 

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -844,9 +844,15 @@ function MouseLine (Lt) {
             var y = (m * x) + b;
             return y;
           };
-          // pixel bounds change w/ browsers
+
+          // pixel bounds change w/ browsers & zoom levels
           var pixelBounds = map.getPixelBounds();
-          var xOne = pixelBounds.min.x;
+          var xOne = 2 * pixelBounds.min.x;
+
+          if (xOne > 0) { // Must be negative
+            xOne = xOne * -1;
+          };
+
           var xTwo = 2 * pixelBounds.max.x;
           var yOne  = linearEq(xOne) || pixelBounds.min.y;
           var yTwo = linearEq(xTwo) || pixelBounds.max.y;
@@ -858,15 +864,11 @@ function MouseLine (Lt) {
 
           // need 3 polylines so lines cover screen
           this.layer.addLayer(L.polyline([latLng, latLngOne],
-              {interactive: false, color: color, opacity: '.75',
+              {interactive: false, color: '#ffffff', opacity: '.75',
                 weight: '3'}));
 
-          this.layer.addLayer(L.polyline([latLng, mouseLatLng],
-              {interactive: false, color: color, opacity: '.75',
-                weight: '3'}));
-
-          this.layer.addLayer(L.polyline([mouseLatLng, latLngTwo],
-              {interactive: false, color: color, opacity: '.75',
+          this.layer.addLayer(L.polyline([latLng, latLngTwo],
+              {interactive: false, color: '#ff0000', opacity: '.75',
                 weight: '3'}));
 
         } else {

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -757,7 +757,7 @@ function MarkerIcon(color, imagePath) {
 function MouseLine (Lt) {
   this.layer = L.layerGroup().addTo(Lt.viewer);
   this.active = false;
-  this.entireScreenLength = false;
+  this.pathGuide = false;
 
   this.btn = new Button ('expand', 'Enable h-bar path guide',
              () => { Lt.disableTools; this.btn.state('active'); this.pathGuide = true },

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -757,6 +757,7 @@ function MarkerIcon(color, imagePath) {
 function MouseLine (Lt) {
   this.layer = L.layerGroup().addTo(Lt.viewer);
   this.active = false;
+  this.entireScreenLength = false;
 
   /**
    * Enable the mouseline
@@ -3435,6 +3436,7 @@ MeasurementOptions.prototype.displayDialog = function () {
     if (window.name.includes('popout')) {
       hbarGrowthRadio.disabled = false;
       hbarFullscreenRadio.disabled = false;
+      this.prefBtnListener();
     } else { // only change option in measurement mode
       hbarGrowthRadio.disabled = true;
       hbarFullscreenRadio.disabled = true;

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -791,11 +791,7 @@ function MouseLine (Lt) {
   MouseLine.prototype.from = function(latLng) {
     var newX, newY;
 
-    var scalerCoefficient = 1.3; // h-bar legs will grow & shrink as mouse moves
-
-    // new X or Y = coordinate X or Y + scaler * (h-bar length)
-    // h-bar length: difference between (mouse point X or Y) & (point X or Y)
-    // scaler: multiplier to increase h-bar leg length
+    var scalerCoefficient = 1.3; // multiplys length between point & mouse
     function newCoordCalc (pointA, pointB, pointC) {
       return pointA + (scalerCoefficient * (pointB - pointC));
     };
@@ -838,6 +834,9 @@ function MouseLine (Lt) {
           var m = (mousePoint.y - point.y) / (mousePoint.x - point.x);
           var b = point.y - (m * point.x);
 
+          // find x value along a line some distance away
+          // found by combining linear equation & distance equation
+          // https://math.stackexchange.com/questions/175896/finding-a-point-along-a-line-a-certain-distance-away-from-another-point
           function distanceToX (xNaut, distance) {
             var x = xNaut + (distance / (Math.sqrt(1 + (m ** 2))));
             return x;
@@ -847,9 +846,6 @@ function MouseLine (Lt) {
             var y = (m * x) + b;
             return y;
           };
-
-          // pixel bounds change w/ browsers & zoom levels
-          var pixelBounds = map.getPixelBounds();
 
           var pathLength = 100;
           if (mousePoint.x < point.x) { // mouse left of point
@@ -887,7 +883,7 @@ function MouseLine (Lt) {
                 weight: '3'}));
 
         };
-        
+
         this.layer.addLayer(L.polyline([latLng, latLngOne],
             {interactive: false, color: color, opacity: '.75',
               weight: '3'}));

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -847,7 +847,7 @@ function MouseLine (Lt) {
           // pixel bounds change w/ browsers
           var pixelBounds = map.getPixelBounds();
           var xOne = pixelBounds.min.x;
-          var xTwo = pixelBounds.max.x;
+          var xTwo = 2 * pixelBounds.max.x;
           var yOne  = linearEq(xOne) || pixelBounds.min.y;
           var yTwo = linearEq(xTwo) || pixelBounds.max.y;
 

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -864,11 +864,11 @@ function MouseLine (Lt) {
 
           // need 3 polylines so lines cover screen
           this.layer.addLayer(L.polyline([latLng, latLngOne],
-              {interactive: false, color: '#ffffff', opacity: '.75',
+              {interactive: false, color: color, opacity: '.75',
                 weight: '3'}));
 
           this.layer.addLayer(L.polyline([latLng, latLngTwo],
-              {interactive: false, color: '#ff0000', opacity: '.75',
+              {interactive: false, color: color, opacity: '.75',
                 weight: '3'}));
 
         } else {

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -3417,6 +3417,8 @@ MeasurementOptions.prototype.displayDialog = function () {
     var backwardRadio = document.getElementById("backward_radio");
     var annualRadio = document.getElementById("annual_radio");
     var subAnnualRadio = document.getElementById("subannual_radio");
+    var hbarGrowthRadio = document.getElementById("hbar_growth_radio");
+    var hbarFullscreenRadio = document.getElementById("hbar_fullscreen_radio");
     if ((Lt.data.points.length === 0 || !Lt.data.points[0]) && window.name.includes('popout')) {
       forwardRadio.disabled = false;
       backwardRadio.disabled = false;
@@ -3429,6 +3431,14 @@ MeasurementOptions.prototype.displayDialog = function () {
       annualRadio.disabled = true;
       subAnnualRadio.disabled = true;
     };
+
+    if (window.name.includes('popout')) {
+      hbarGrowthRadio.disabled = false;
+      hbarFullscreenRadio.disabled = false;
+    } else { // only change option in measurement mode
+      hbarGrowthRadio.disabled = true;
+      hbarFullscreenRadio.disabled = true;
+    }
 
     this.dialog.lock();
     this.dialog.open();


### PR DESCRIPTION
<table>
<tr>
<td>Figure 1. <img src="https://user-images.githubusercontent.com/68254973/92154934-35dd9400-edec-11ea-93a6-736f2c197e92.png"  width="400"></td>
<td>Figure 2. <img src="https://user-images.githubusercontent.com/68254973/92152812-ec3f7a00-ede8-11ea-897f-98f9bc28c888.jpg"  width="400" height="290"></td>
</tr>
</table>

How the h-bar legs (sections perpendicular to line between mouse & point) are created has been simplified (Figure 1). At its core, the h-bar legs are a 90 degree rotation of the section between the mouse & point. Also, the legs have been extended by 1.3 times the distance between the mouse & point.  

A new button under 'Image and Measurement Settings' will toggle a path guide on and off. The path guide helps users make straight measurement paths. Path guide are created by (Figure 2):
1. Finding the X-value some distance (100 pixels in this case)  from the mouse or point along the linear line created by the mouse & point. 
2. Plugging it into the linear equation of the line between the mouse & point to find the Y-value. 
3. Using Leaflet's polyline to draw a line between the calculated X & Y-value.

An undefined slope due to a vertical line (mouse is directly blow or above the point) have been accounted for (line 870-871). 

