### PR TITLE
Year pop up to only occur on first start point not all. 

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -1895,10 +1895,10 @@ function CreatePoint(Lt) {
       Lt.undo.push();
 
       if (this.startPoint) {
-        if (Lt.data.points.length <= 1) {
+        if (Lt.data.points.length <= 1) { // only pop up for first start point
           var popup = L.popup({closeButton: false}).setContent(
-              '<input type="number" style="border:none; width:50px;"' +
-              'value="' + Lt.data.year + '" id="year_input"></input>')
+              '<input type="number" style="border:none; width:50px;" \
+              value="0" id="year_input"></input>')
               .setLatLng(latLng)
               .openOn(Lt.viewer);
 

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -1895,21 +1895,24 @@ function CreatePoint(Lt) {
       Lt.undo.push();
 
       if (this.startPoint) {
-        var popup = L.popup({closeButton: false}).setContent(
-            '<input type="number" style="border:none; width:50px;"' +
-            'value="' + Lt.data.year + '" id="year_input"></input>')
-            .setLatLng(latLng)
-            .openOn(Lt.viewer);
+        if (Lt.data.points.length <= 1) {
+          var popup = L.popup({closeButton: false}).setContent(
+              '<input type="number" style="border:none; width:50px;"' +
+              'value="' + Lt.data.year + '" id="year_input"></input>')
+              .setLatLng(latLng)
+              .openOn(Lt.viewer);
 
-        document.getElementById('year_input').select();
+              document.getElementById('year_input').select();
 
-        $(document).keypress(e => {
-          var key = e.which || e.keyCode;
-          if (key === 13) {
-            Lt.data.year = parseInt(document.getElementById('year_input').value);
-            popup.remove(Lt.viewer);
-          }
-        });
+              $(document).keypress(e => {
+                var key = e.which || e.keyCode;
+                if (key === 13) {
+                  Lt.data.year = parseInt(document.getElementById('year_input').value);
+                  popup.remove(Lt.viewer);
+                }
+              });
+        }
+
         Lt.data.newPoint(this.startPoint, latLng);
         this.startPoint = false;
       } else {


### PR DESCRIPTION
Previously, whenever a start point was placed, a dialog box with the year would pop up allowing users to change the year. This is an issue because users could 'break' the year sequence by adding a year not in the immediate series (i.e. 1999 2000 ^pop up^ 2010 2011.)

It is now disabled for all points except the first start point. 

A future change could be allowing start points after break points to change their year since multi year breaks occur. 

Tested on Chrome & Firefox with no apparent issues. 