### PR TITLE
Inserting a point while measuring backwards bug

### DIFF
--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -452,7 +452,7 @@ function MeasurementData (dataObject, Lt) {
 
     k++;
 
-    second_points.map((e, i) => {
+    second_points.map(e => {
       if(!e) {
        return;
       }

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -405,7 +405,7 @@ function MeasurementData (dataObject, Lt) {
     };
 
     var new_points = this.points;
-    var second_points = this.points.slice().splice(i, this.index - 1);
+    var second_points = this.points.slice().splice(i);
     var k = i;
     var year_adjusted;
     var earlywood_adjusted = true;
@@ -421,7 +421,11 @@ function MeasurementData (dataObject, Lt) {
 
       } else if (this.points[i - 1].start || this.points[i].start) { // case 2: previous or closest point is start
           year_adjusted = this.points[i].year;
-          if ((this.points[i - 2] && this.points[i - 2].earlywood && measurementOptions.subAnnual) || direction == backwardInTime) {
+          if (this.points[i - 2] && this.points[i - 2].earlywood && measurementOptions.subAnnual && direction == forwardInTime) {
+            earlywood_adjusted = false;
+          } else if (this.points[i - 2] && !this.points[i - 2].earlywood && measurementOptions.subAnnual && direction == backwardInTime) {
+            earlywood_adjusted = true;
+          } else if (direction == backwardInTime) {
             earlywood_adjusted = false;
           };
 
@@ -448,7 +452,7 @@ function MeasurementData (dataObject, Lt) {
 
     k++;
 
-    second_points.map(e => {
+    second_points.map((e, i) => {
       if(!e) {
        return;
       }

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -410,7 +410,7 @@ function MeasurementData (dataObject, Lt) {
     var year_adjusted;
     var earlywood_adjusted = true;
 
-    if (this.points[i - 1]) {
+    if (this.points[i - 1] && this.points[i]) {
       if (this.points[i - 1].earlywood && measurementOptions.subAnnual) { // case 1: subAnnual enabled & previous point ew
         earlywood_adjusted = false;
         if (direction == forwardInTime) {


### PR DESCRIPTION
If statement which handled inserting points near a start point while measuring backwards assumed the previous point would be an earlywood point. Changed code so there are more exceptions to avoid this error. 