### PR TITLE
Issue 31 Fix : Year shifting for editing tools (convert  to start tool).

### DIFF
--- a/_site/leaflet-treering.js
+++ b/_site/leaflet-treering.js
@@ -597,6 +597,81 @@ function MeasurementData (dataObject, Lt) {
   };
 
   /**
+   * Convert a point to a start point
+   * @function convertToStartPoint
+   */
+  MeasurementData.prototype.convertToStartPoint = function(i) {
+    let direction = directionCheck();
+    // Points are lagged when measuring backwards, need to account for. 
+    if (direction == backwardInTime) i++;
+    let tempDirection = (Lt.convertToStartPoint.adjustOuter) ? backwardInTime : forwardInTime;
+
+    var points = Lt.data.points;
+    var previousYear = points[i].year || 0;
+
+    // Convert to start point by changing properties.
+    points[i].start = true;
+    let tempYear = points[i].year;
+    delete points[i].year;
+    delete points[i].earlywood;
+
+    // Remove orphanned start points.
+    if (points[i - 1].start) {
+      Lt.deletePoint.action(i - 1);
+    };
+    if (points[i + 1].start) {
+      Lt.deletePoint.action(i);
+    }
+
+    let new_points = JSON.parse(JSON.stringify(this.points));
+    let second_points = (direction == tempDirection) ? JSON.parse(JSON.stringify(this.points)).slice(0, i) : JSON.parse(JSON.stringify(this.points)).slice(i + 1);
+
+    let year_adjustment = (Lt.convertToStartPoint.adjustOuter) ? -1 : 1;
+    let index_adjustment = (direction == tempDirection) ? 0 : i + 1;
+    second_points.map((e, k) => {
+      if (!e) return;
+      if (!e.start && !e.break) {
+        if (measurementOptions.subAnnual) e.earlywood = !e.earlywood;
+        if (
+            (Lt.convertToStartPoint.adjustOuter && !e.earlywood) || // When adjusting outer portion, change year at latewood instance.
+            (!Lt.convertToStartPoint.adjustOuter && e.earlywood) || // When adjusting inner portion, change year at earlywood instance.
+            !measurementOptions.subAnnual
+           ) {
+          e.year = e.year + year_adjustment;
+        }
+      };
+      new_points[index_adjustment + k] = e;
+    });
+
+    this.points = new_points;
+    this.index = (new_points.length - 1 > 0) ? new_points.length - 1 : 0;
+    let lastIndex = new_points.length - 1;
+    // If only a start point exists, reset data.
+    if (!this.points[lastIndex].year) {
+      this.year = 0;
+      this.earlywood = true;
+    } else {
+      // Determine next measurement point by last existing point.
+      if (measurementOptions.subAnnual) {
+        this.earlywood = !(this.points[lastIndex].earlywood)
+        if (direction == forwardInTime) {
+          this.year = (this.points[lastIndex].earlywood) ? this.points[lastIndex].year : this.points[lastIndex].year + 1;
+        } else if (direction == backwardInTime) {
+          this.year = (this.points[lastIndex].earlywood) ? this.points[lastIndex].year - 1 : this.points[lastIndex].year;
+        }
+      } else {
+        this.year = (direction == forwardInTime) ? this.points[lastIndex].year + 1 : this.points[lastIndex].year - 1;
+      }
+    }
+
+    Lt.metaDataText.updateText();
+    Lt.annotationAsset.reloadAssociatedYears();
+    if (Lt.popoutPlots.win) {
+      Lt.popoutPlots.sendData();
+    }
+  }
+
+  /**
    * Insert a zero growth year in the middle of the measurement data
    * @function insertZeroGrowth
    */
@@ -620,7 +695,7 @@ function MeasurementData (dataObject, Lt) {
     // New points:  --- | --- | --- | --- || | --- | --- | --- | ---
     // Increments:      e     l     e     le l     e     l     e
     // Years:           0     1     1     12 2     3     3     4
-    // Indices:        i-5   i-4   i-3   i-1 i    i+1   i+3   i+4 
+    // Indices:        i-5   i-4   i-3   i-1 i    i+1   i+3   i+4
     //                                   i-2
 
     let direction = directionCheck();
@@ -669,8 +744,8 @@ function MeasurementData (dataObject, Lt) {
     let year_adjustment = (Lt.insertZeroGrowth.adjustOuter) ? 1 : -1;
     let index_adjustment = (direction == tempDirection) ? 0 : k;
     // When inserting a sub-annual zero growth point, must slice after the second inserted point.
-    let slice_indexA = (Lt.measurementOptions.subAnnual) ? i : i - 1;
-    let slice_indexB = (Lt.measurementOptions.subAnnual) ? i : i + 1;
+    let slice_indexA = (!Lt.measurementOptions.subAnnual) ? i : i - 1;
+    let slice_indexB = (!Lt.measurementOptions.subAnnual) ? i : i + 1;
     let second_points = (direction == tempDirection) ? JSON.parse(JSON.stringify(this.points)).slice(0, slice_indexA) :
                                                        JSON.parse(JSON.stringify(this.points)).slice(slice_indexB);
 
@@ -828,6 +903,10 @@ function MarkerIcon(color, imagePath) {
     'empty'      : { 'path': imagePath + 'images/Empty.png',
                      'size': [0, 0] },
   };
+
+  if (!colors[color]?.path) {
+    console.log("Color path error: ", color);
+  }
 
   return L.icon({
     iconUrl : colors[color].path,
@@ -1078,7 +1157,6 @@ function VisualAsset (Lt) {
           } else if (Lt.data.points[i + 1] && Lt.data.points[i + 1].start) {
             tooltip = 'Start';
           }
-
           // First point is treated as a measurement point, not a start point.
           if (i === 0 && Lt.data.points[i + 1]) {
             var desc = (!Lt.measurementOptions.subAnnual) ? '' : ', late';
@@ -1197,11 +1275,7 @@ function VisualAsset (Lt) {
       }
     // Break point icon:
     } else if (pts[i].break) {
-      if (forward) {
-          color = 'break';
-      } else if (backward) {
-        color = 'break';
-      }
+      color = 'break';
     // Zero growth point icon:
     } else if (zero ||
               (forward && pts[i - 1] && pts[i].latLng.lat == pts[i - 1].latLng.lat && pts[i].latLng.lng == pts[i - 1].latLng.lng) ||
@@ -1233,11 +1307,25 @@ function VisualAsset (Lt) {
     // Start and end points swapped when measuring backwards.
     // Only apply this when active measuring disabled.
     if (backward && i === 0) {
-      color = (pts[i + 1] && pts[i + 1].year % 10 == 0) ? 'dark_red' :
-              (annual) ? 'light_blue' : 'dark_blue';
-  } else if (backward && i === pts.length - 1 && reload) {
-      color = 'start';
-  }
+      if (pts[i + 1]) {
+        if (subAnnual) {
+          if (pts[i + 1].earlywood) {
+            // Decades are colored red.
+            color = (pts[i + 1].year % 10 == 0) ? 'light_red' : 'dark_blue';
+          } else { // Otherwise, point is latewood.
+            color = (pts[i + 1].year % 10 == 0) ? 'pale_red' : 'light_blue';
+          }
+        } else {
+          color = (pts[i + 1].year % 10 == 0) ? 'light_red' : 'light_blue';
+        }
+      } else {
+        color = (annual) ? 'light_blue' : 'dark_blue';
+      }
+    // Only apply this when active measuring disabled.
+    } else if (backward && i === pts.length - 1 && reload) {
+        color = 'start';
+    }
+
   if (!color) color = 'empty';
   var marker = getMarker(leafLatLng, color, Lt.basePath, draggable);
   this.markers[i] = marker;
@@ -1309,7 +1397,7 @@ function VisualAsset (Lt) {
       };
 
       if (Lt.convertToStartPoint.active) {
-        Lt.convertToStartPoint.action(i);
+        Lt.convertToStartPoint.openDialog(e, i);
       };
 
       if (Lt.cut.active) {
@@ -3834,6 +3922,13 @@ function InsertPoint(Lt) {
  * @param {Ltreering} Lt - Leaflet treering object
  */
 function ConvertToStartPoint(Lt) {
+  this.act = "Convert a measurement point to a start point";
+  this.optA = "shift dating of later years back in time"
+  this.optB = "shift dating of earlier years forward in time"
+  this.adjustOuter = true;
+  this.selectedAdjustment = false;
+  this.maintainAdjustment = false;
+
   this.active = false;
   this.btn = new Button(
     'change_circle',
@@ -3842,64 +3937,36 @@ function ConvertToStartPoint(Lt) {
     () => { this.disable() }
   );
 
-  ConvertToStartPoint.prototype.action = function (i) {
-    var points = Lt.data.points;
-    var previousYear = points[i].year || 0;
-
-    // cannot convert a point that is already a start point
-    // start points are camouflage when measuring backwards.
-    if (points[i].start || (!Lt.measurementOptions.forwardDirection && points[i + 1] && points[i + 1].start)) {
+  /**
+   * Open dialog for user to choose shift direction
+   * @function openDialog
+   */
+  ConvertToStartPoint.prototype.openDialog = function(e, i) {
+    // Cannot convert a point that is already a start point.
+    // Start points are camouflage when measuring backwards.
+    if (Lt.data.points[i].start || Lt.data.points[i].break ||
+        (!Lt.measurementOptions.forwardDirection && Lt.data.points[i + 1] && Lt.data.points[i + 1].start)) {
+      alert("Can only convert measurement points.")
       return;
     }
 
-    Lt.undo.push();
-
-    // convert to start point by changing properties
-    points[i].start = true;
-    delete points[i].year;
-    delete points[i].earlywood;
-
-    if (i - 1 == 0) { // if previous point is first start point
-      Lt.deletePoint.action(i - 1);
-    };
-
-    // re-assign years to following points
-    var previousPoints = points.slice(0, i);
-    var followingPoints = points.slice(i);
-
-    if (Lt.measurementOptions.forwardDirection) { // if measuring forward in time
-      var yearChange = 1;
-    } else { // if measuring backward in time
-      var yearChange = -1;
-    };
-
-    followingPoints.map((c) => {
-      if (c && !c.start && !c.break) {
-        if (Lt.measurementOptions.subAnnual) { // flip earlywood & latewood
-          c.earlywood = !c.earlywood;
-        };
-
-        c.year = previousYear;
-        if (!Lt.measurementOptions.subAnnual ||
-           (Lt.measurementOptions.forwardDirection && !c.earlywood) ||
-           (!Lt.measurementOptions.forwardDirection && c.earlywood)) { // only change year value if latewood or annual measurements
-          previousYear += yearChange;
-        };
-      };
-    });
-
-    Lt.data.year = Lt.measurementOptions.forwardDirection ? points[points.length-1].year + 1: points[points.length-1].year - 1;
-    Lt.visualAsset.reload();
-    Lt.metaDataText.updateText();
-    Lt.annotationAsset.reloadAssociatedYears();
-    if (Lt.popoutPlots.win) {
-      Lt.popoutPlots.sendData();
+    if (this.maintainAdjustment) {
+      this.action(i);
+    } else {
+      Lt.helper.createEditToolDialog(e.containerPoint.x, e.containerPoint.y, i, "convertToStartPoint");
     }
+  };
+
+  ConvertToStartPoint.prototype.action = function (i) {
+    Lt.undo.push();
+    Lt.data.convertToStartPoint(i);
+    Lt.visualAsset.reload();
   };
 
   ConvertToStartPoint.prototype.enable = function () {
     Lt.viewer.getContainer().style.cursor = 'pointer';
     this.btn.state('active');
+    this.selectedAdjustment = false;
     this.active = true;
   };
 
@@ -3913,6 +3980,7 @@ function ConvertToStartPoint(Lt) {
 
     $(Lt.viewer.getContainer()).off('click');
     this.btn.state('inactive');
+    this.selectedAdjustment = false;
     this.active = false;
     Lt.viewer.getContainer().style.cursor = 'default';
   };

--- a/_site/leaflet-treering.js
+++ b/_site/leaflet-treering.js
@@ -602,7 +602,7 @@ function MeasurementData (dataObject, Lt) {
    */
   MeasurementData.prototype.convertToStartPoint = function(i) {
     let direction = directionCheck();
-    // Points are lagged when measuring backwards, need to account for. 
+    // Points are lagged when measuring backwards, need to account for.
     if (direction == backwardInTime) i++;
     let tempDirection = (Lt.convertToStartPoint.adjustOuter) ? backwardInTime : forwardInTime;
 
@@ -616,11 +616,11 @@ function MeasurementData (dataObject, Lt) {
     delete points[i].earlywood;
 
     // Remove orphanned start points.
-    if (points[i - 1].start) {
-      Lt.deletePoint.action(i - 1);
-    };
-    if (points[i + 1].start) {
-      Lt.deletePoint.action(i);
+    if (points[i - 1]?.start) {
+      delete points[i - 1];
+    }
+    if (points[i + 1]?.start) {
+      delete points[i];
     }
 
     let new_points = JSON.parse(JSON.stringify(this.points));
@@ -643,8 +643,12 @@ function MeasurementData (dataObject, Lt) {
       new_points[index_adjustment + k] = e;
     });
 
+    new_points = new_points.filter(Boolean);
     this.points = new_points;
-    this.index = (new_points.length - 1 > 0) ? new_points.length - 1 : 0;
+    // Removes orphanned end point.
+    if (this.points[new_points.length - 1]?.start) this.points.pop();
+    this.index = (new_points.length - 1 > 0) ? new_points.length : 0;
+
     let lastIndex = new_points.length - 1;
     // If only a start point exists, reset data.
     if (!this.points[lastIndex].year) {

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -602,7 +602,7 @@ function MeasurementData (dataObject, Lt) {
    */
   MeasurementData.prototype.convertToStartPoint = function(i) {
     let direction = directionCheck();
-    // Points are lagged when measuring backwards, need to account for. 
+    // Points are lagged when measuring backwards, need to account for.
     if (direction == backwardInTime) i++;
     let tempDirection = (Lt.convertToStartPoint.adjustOuter) ? backwardInTime : forwardInTime;
 
@@ -616,11 +616,11 @@ function MeasurementData (dataObject, Lt) {
     delete points[i].earlywood;
 
     // Remove orphanned start points.
-    if (points[i - 1].start) {
-      Lt.deletePoint.action(i - 1);
-    };
-    if (points[i + 1].start) {
-      Lt.deletePoint.action(i);
+    if (points[i - 1]?.start) {
+      delete points[i - 1];
+    }
+    if (points[i + 1]?.start) {
+      delete points[i];
     }
 
     let new_points = JSON.parse(JSON.stringify(this.points));
@@ -643,8 +643,12 @@ function MeasurementData (dataObject, Lt) {
       new_points[index_adjustment + k] = e;
     });
 
+    new_points = new_points.filter(Boolean);
     this.points = new_points;
-    this.index = (new_points.length - 1 > 0) ? new_points.length - 1 : 0;
+    // Removes orphanned end point.
+    if (this.points[new_points.length - 1]?.start) this.points.pop();
+    this.index = (new_points.length - 1 > 0) ? new_points.length : 0;
+
     let lastIndex = new_points.length - 1;
     // If only a start point exists, reset data.
     if (!this.points[lastIndex].year) {

--- a/leaflet-treering.js
+++ b/leaflet-treering.js
@@ -597,6 +597,81 @@ function MeasurementData (dataObject, Lt) {
   };
 
   /**
+   * Convert a point to a start point
+   * @function convertToStartPoint
+   */
+  MeasurementData.prototype.convertToStartPoint = function(i) {
+    let direction = directionCheck();
+    // Points are lagged when measuring backwards, need to account for. 
+    if (direction == backwardInTime) i++;
+    let tempDirection = (Lt.convertToStartPoint.adjustOuter) ? backwardInTime : forwardInTime;
+
+    var points = Lt.data.points;
+    var previousYear = points[i].year || 0;
+
+    // Convert to start point by changing properties.
+    points[i].start = true;
+    let tempYear = points[i].year;
+    delete points[i].year;
+    delete points[i].earlywood;
+
+    // Remove orphanned start points.
+    if (points[i - 1].start) {
+      Lt.deletePoint.action(i - 1);
+    };
+    if (points[i + 1].start) {
+      Lt.deletePoint.action(i);
+    }
+
+    let new_points = JSON.parse(JSON.stringify(this.points));
+    let second_points = (direction == tempDirection) ? JSON.parse(JSON.stringify(this.points)).slice(0, i) : JSON.parse(JSON.stringify(this.points)).slice(i + 1);
+
+    let year_adjustment = (Lt.convertToStartPoint.adjustOuter) ? -1 : 1;
+    let index_adjustment = (direction == tempDirection) ? 0 : i + 1;
+    second_points.map((e, k) => {
+      if (!e) return;
+      if (!e.start && !e.break) {
+        if (measurementOptions.subAnnual) e.earlywood = !e.earlywood;
+        if (
+            (Lt.convertToStartPoint.adjustOuter && !e.earlywood) || // When adjusting outer portion, change year at latewood instance.
+            (!Lt.convertToStartPoint.adjustOuter && e.earlywood) || // When adjusting inner portion, change year at earlywood instance.
+            !measurementOptions.subAnnual
+           ) {
+          e.year = e.year + year_adjustment;
+        }
+      };
+      new_points[index_adjustment + k] = e;
+    });
+
+    this.points = new_points;
+    this.index = (new_points.length - 1 > 0) ? new_points.length - 1 : 0;
+    let lastIndex = new_points.length - 1;
+    // If only a start point exists, reset data.
+    if (!this.points[lastIndex].year) {
+      this.year = 0;
+      this.earlywood = true;
+    } else {
+      // Determine next measurement point by last existing point.
+      if (measurementOptions.subAnnual) {
+        this.earlywood = !(this.points[lastIndex].earlywood)
+        if (direction == forwardInTime) {
+          this.year = (this.points[lastIndex].earlywood) ? this.points[lastIndex].year : this.points[lastIndex].year + 1;
+        } else if (direction == backwardInTime) {
+          this.year = (this.points[lastIndex].earlywood) ? this.points[lastIndex].year - 1 : this.points[lastIndex].year;
+        }
+      } else {
+        this.year = (direction == forwardInTime) ? this.points[lastIndex].year + 1 : this.points[lastIndex].year - 1;
+      }
+    }
+
+    Lt.metaDataText.updateText();
+    Lt.annotationAsset.reloadAssociatedYears();
+    if (Lt.popoutPlots.win) {
+      Lt.popoutPlots.sendData();
+    }
+  }
+
+  /**
    * Insert a zero growth year in the middle of the measurement data
    * @function insertZeroGrowth
    */
@@ -620,7 +695,7 @@ function MeasurementData (dataObject, Lt) {
     // New points:  --- | --- | --- | --- || | --- | --- | --- | ---
     // Increments:      e     l     e     le l     e     l     e
     // Years:           0     1     1     12 2     3     3     4
-    // Indices:        i-5   i-4   i-3   i-1 i    i+1   i+3   i+4 
+    // Indices:        i-5   i-4   i-3   i-1 i    i+1   i+3   i+4
     //                                   i-2
 
     let direction = directionCheck();
@@ -669,8 +744,8 @@ function MeasurementData (dataObject, Lt) {
     let year_adjustment = (Lt.insertZeroGrowth.adjustOuter) ? 1 : -1;
     let index_adjustment = (direction == tempDirection) ? 0 : k;
     // When inserting a sub-annual zero growth point, must slice after the second inserted point.
-    let slice_indexA = (Lt.measurementOptions.subAnnual) ? i : i - 1;
-    let slice_indexB = (Lt.measurementOptions.subAnnual) ? i : i + 1;
+    let slice_indexA = (!Lt.measurementOptions.subAnnual) ? i : i - 1;
+    let slice_indexB = (!Lt.measurementOptions.subAnnual) ? i : i + 1;
     let second_points = (direction == tempDirection) ? JSON.parse(JSON.stringify(this.points)).slice(0, slice_indexA) :
                                                        JSON.parse(JSON.stringify(this.points)).slice(slice_indexB);
 
@@ -828,6 +903,10 @@ function MarkerIcon(color, imagePath) {
     'empty'      : { 'path': imagePath + 'images/Empty.png',
                      'size': [0, 0] },
   };
+
+  if (!colors[color]?.path) {
+    console.log("Color path error: ", color);
+  }
 
   return L.icon({
     iconUrl : colors[color].path,
@@ -1196,7 +1275,7 @@ function VisualAsset (Lt) {
       }
     // Break point icon:
     } else if (pts[i].break) {
-      color = 'white_break';
+      color = 'break';
     // Zero growth point icon:
     } else if (zero ||
               (forward && pts[i - 1] && pts[i].latLng.lat == pts[i - 1].latLng.lat && pts[i].latLng.lng == pts[i - 1].latLng.lng) ||
@@ -1244,7 +1323,7 @@ function VisualAsset (Lt) {
       }
     // Only apply this when active measuring disabled.
     } else if (backward && i === pts.length - 1 && reload) {
-        color = 'white_start';
+        color = 'start';
     }
 
   if (!color) color = 'empty';
@@ -1318,7 +1397,7 @@ function VisualAsset (Lt) {
       };
 
       if (Lt.convertToStartPoint.active) {
-        Lt.convertToStartPoint.action(i);
+        Lt.convertToStartPoint.openDialog(e, i);
       };
 
       if (Lt.cut.active) {
@@ -3843,6 +3922,13 @@ function InsertPoint(Lt) {
  * @param {Ltreering} Lt - Leaflet treering object
  */
 function ConvertToStartPoint(Lt) {
+  this.act = "Convert a measurement point to a start point";
+  this.optA = "shift dating of later years back in time"
+  this.optB = "shift dating of earlier years forward in time"
+  this.adjustOuter = true;
+  this.selectedAdjustment = false;
+  this.maintainAdjustment = false;
+
   this.active = false;
   this.btn = new Button(
     'change_circle',
@@ -3851,64 +3937,36 @@ function ConvertToStartPoint(Lt) {
     () => { this.disable() }
   );
 
-  ConvertToStartPoint.prototype.action = function (i) {
-    var points = Lt.data.points;
-    var previousYear = points[i].year || 0;
-
-    // cannot convert a point that is already a start point
-    // start points are camouflage when measuring backwards.
-    if (points[i].start || (!Lt.measurementOptions.forwardDirection && points[i + 1] && points[i + 1].start)) {
+  /**
+   * Open dialog for user to choose shift direction
+   * @function openDialog
+   */
+  ConvertToStartPoint.prototype.openDialog = function(e, i) {
+    // Cannot convert a point that is already a start point.
+    // Start points are camouflage when measuring backwards.
+    if (Lt.data.points[i].start || Lt.data.points[i].break ||
+        (!Lt.measurementOptions.forwardDirection && Lt.data.points[i + 1] && Lt.data.points[i + 1].start)) {
+      alert("Can only convert measurement points.")
       return;
     }
 
-    Lt.undo.push();
-
-    // convert to start point by changing properties
-    points[i].start = true;
-    delete points[i].year;
-    delete points[i].earlywood;
-
-    if (i - 1 == 0) { // if previous point is first start point
-      Lt.deletePoint.action(i - 1);
-    };
-
-    // re-assign years to following points
-    var previousPoints = points.slice(0, i);
-    var followingPoints = points.slice(i);
-
-    if (Lt.measurementOptions.forwardDirection) { // if measuring forward in time
-      var yearChange = 1;
-    } else { // if measuring backward in time
-      var yearChange = -1;
-    };
-
-    followingPoints.map((c) => {
-      if (c && !c.start && !c.break) {
-        if (Lt.measurementOptions.subAnnual) { // flip earlywood & latewood
-          c.earlywood = !c.earlywood;
-        };
-
-        c.year = previousYear;
-        if (!Lt.measurementOptions.subAnnual ||
-           (Lt.measurementOptions.forwardDirection && !c.earlywood) ||
-           (!Lt.measurementOptions.forwardDirection && c.earlywood)) { // only change year value if latewood or annual measurements
-          previousYear += yearChange;
-        };
-      };
-    });
-
-    Lt.data.year = Lt.measurementOptions.forwardDirection ? points[points.length-1].year + 1: points[points.length-1].year - 1;
-    Lt.visualAsset.reload();
-    Lt.metaDataText.updateText();
-    Lt.annotationAsset.reloadAssociatedYears();
-    if (Lt.popoutPlots.win) {
-      Lt.popoutPlots.sendData();
+    if (this.maintainAdjustment) {
+      this.action(i);
+    } else {
+      Lt.helper.createEditToolDialog(e.containerPoint.x, e.containerPoint.y, i, "convertToStartPoint");
     }
+  };
+
+  ConvertToStartPoint.prototype.action = function (i) {
+    Lt.undo.push();
+    Lt.data.convertToStartPoint(i);
+    Lt.visualAsset.reload();
   };
 
   ConvertToStartPoint.prototype.enable = function () {
     Lt.viewer.getContainer().style.cursor = 'pointer';
     this.btn.state('active');
+    this.selectedAdjustment = false;
     this.active = true;
   };
 
@@ -3922,6 +3980,7 @@ function ConvertToStartPoint(Lt) {
 
     $(Lt.viewer.getContainer()).off('click');
     this.btn.state('inactive');
+    this.selectedAdjustment = false;
     this.active = false;
     Lt.viewer.getContainer().style.cursor = 'default';
   };


### PR DESCRIPTION
Adding year shifting option to all editing tools. Shifting outer refers to the portion of measurements with newer years (closer to 2020) and shifting inner refers to older years (closer to 1500). Some overlap between how each tool handles the shifting, could be generalized in the future (i.e. cutting points is equivalent to deleting multiple points.)

This request is convert to start tool specific. 