### PR TITLE
Bug fixes 11/20/23

### DIFF
--- a/Leaflet.AreaCapture.js
+++ b/Leaflet.AreaCapture.js
@@ -1124,15 +1124,21 @@ function DateEllipses(Inte) {
      * @param {integer} year - New year value. 
      */
     DateEllipses.prototype.action = function(year) {
+        let floatYear = parseFloat(year);
+        let intYear = (year >= 0) ? Math.floor(year) : Math.ceil(year);
+        let trailingNums = parseFloat((floatYear - intYear).toFixed(2));
+
         // Push change to undo stack: 
         Inte.treering.undo.push();
 
         let selectedValue = $('input[name="AreaCapture-dateRadioBtn-value"]:checked').val();
         
         let selectedYear = Inte.ellipseData.selectedData[0].year;
-        let deltaYear = year - selectedYear;
-        let otherEllipses = [];
+        let intSelectedYear = Math.floor(selectedYear);
 
+        let deltaYear = intYear - intSelectedYear;
+
+        let otherEllipses = [];
         switch(selectedValue) {
             case(this.forwardValue): {
                 otherEllipses = Inte.ellipseData.data.filter(ele => ele.year > selectedYear);
@@ -1145,7 +1151,10 @@ function DateEllipses(Inte) {
         }
 
         otherEllipses.map(ele => {
-            ele.year += deltaYear;
+            let yearIntShift = Math.floor(ele.year) + deltaYear
+            if (yearIntShift < 0) trailingNums = -1 * Math.abs(trailingNums); // Sign must be the same as year (+/-).
+            ele.year = yearIntShift + trailingNums;
+
             ele.color = Inte.ellipseVisualAssets.getColorFromCycle(ele.year);
         });
 

--- a/Leaflet.DataAccess.js
+++ b/Leaflet.DataAccess.js
@@ -652,19 +652,29 @@ function Download(Inte) {
         let dat = Inte.treering.helper.findDistances();
 
         let name = this.constructNameRWL(Inte.treering.meta.assetName);
+        let year = dat.tw.x[0];
         let stopMarker = " -9999";
-
+        
         let outTWStr = name + dat.tw.x[0] + this.formatDataPointRWL(dat.tw.y[0]);
+        // If data begins on a year ending in '9', begin newline immediately.
+        if ((year + 1) % 10 == 0) outTWStr += "\n" + name + (year + 1);;
+
         let outEWStr = "";
         let outLWStr = "";
 
         if (dat?.ew) {
-            outEWStr = name + dat.ew.x[0] + this.formatDataPointRWL(dat.ew.y[0]);
-            outLWStr = name + dat.lw.x[0] + this.formatDataPointRWL(dat.lw.y[0]);
+            let yearEW = dat.ew.x[0];
+            let yearLW = dat.lw.x[0];
+
+            outEWStr = name + yearEW + this.formatDataPointRWL(dat.ew.y[0]);
+            outLWStr = name + yearLW + this.formatDataPointRWL(dat.lw.y[0]);
+
+            if ((yearEW + 1) % 10 == 0) outEWStr += "\n" + name + (yearEW + 1);;
+            if ((yearLW + 1) % 10 == 0) outLWStr += "\n" + name + (yearLW + 1);;
         }
 
         for (let i = 1; i < dat.tw.x.length; i++) {
-            let year = dat.tw.x[i];
+            year = dat.tw.x[i];
             outTWStr += this.formatDataPointRWL(dat.tw.y[i]);
 
             if (dat?.ew) {

--- a/Leaflet.DataAccess.js
+++ b/Leaflet.DataAccess.js
@@ -710,6 +710,10 @@ function Download(Inte) {
     Download.prototype.formatDataPointRWL = function(dataPoint) {
         dataPoint *= 1000;
         dataPoint = Math.round(dataPoint);
+
+        // Change 0.999mm measurements to 0.998mm for software compatibility. 
+        if (dataPoint == 999) dataPoint = 998;
+
         dataPoint = String(dataPoint);
         dataPoint = " ".repeat(6 - dataPoint.length) + dataPoint;
 


### PR DESCRIPTION
Bugs fixed: 

1. Cores with a first measurement year ending in -9 must begin newline immediately. 
2. Cores with 0.999mm measurement must be 0.998mm for software compatibility. 
3. Dating cores with decimals rounds values correctly (2 decimal places). 